### PR TITLE
Cleanup Erroneous Imports

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,14 +5,13 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"path/filepath"
 
 	"os"
 
 	"encoding/json"
 
 	"log"
-
-	"pkg/path/filepath"
 
 	"github.com/Nitecon/1Password/utils"
 	"github.com/julienschmidt/httprouter"

--- a/utils/config.go
+++ b/utils/config.go
@@ -7,10 +7,9 @@ import (
 	"os"
 	"os/user"
 	"path"
+	"path/filepath"
 	"runtime"
 	"sync"
-
-	"pkg/path/filepath"
 
 	"github.com/syndtr/goleveldb/leveldb/errors"
 )


### PR DESCRIPTION
1Password throws errors on `go get` and `go build` due to these imports, cleaned them up. 